### PR TITLE
Feature/registering domains

### DIFF
--- a/app/Actions/Auth/CreateSubdomainAction.php
+++ b/app/Actions/Auth/CreateSubdomainAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Actions\Auth;
+
+use App\DataTransferObjects\Auth\SubdomainData;
+use App\Models\Subdomain;
+
+class CreateSubdomainAction
+{
+    public function execute(SubdomainData $data): Subdomain
+    {
+        return Subdomain::create([
+            'name' => $data->name,
+            'user_id' => $data->user->id,
+        ]);
+    }
+}

--- a/app/DataTransferObjects/Auth/SubdomainData.php
+++ b/app/DataTransferObjects/Auth/SubdomainData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\DataTransferObjects\Auth;
+
+use App\Models\User;
+
+class SubdomainData
+{
+    public function __construct(
+        public string $name,
+        public User $user,
+    ) {
+    }
+}

--- a/app/Http/Controllers/Auth/RegisterSubdomainController.php
+++ b/app/Http/Controllers/Auth/RegisterSubdomainController.php
@@ -18,7 +18,9 @@ class RegisterSubdomainController extends Controller
 
     public function store(CreateSubdomainAction $action, SubdomainRequest $request)
     {
-        $data = new SubdomainData(...$request->validated(), user: $request->user());
+        $data = new SubdomainData(
+            ...array_merge($request->validated(), ['user' => $request->user()])
+        );
 
         $subdomain = $action->execute($data);
 

--- a/app/Http/Controllers/Auth/RegisterSubdomainController.php
+++ b/app/Http/Controllers/Auth/RegisterSubdomainController.php
@@ -6,6 +6,7 @@ use App\Actions\Auth\CreateSubdomainAction;
 use App\DataTransferObjects\Auth\SubdomainData;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\SubdomainRequest;
+use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -21,5 +22,12 @@ class RegisterSubdomainController extends Controller
         $data = new SubdomainData(...$request->validated(), user: $request->user());
 
         $subdomain = $action->execute($data);
+
+        return Inertia::location(route('subdomain.home', ['subdomain' => $subdomain]));
+    }
+
+    public function example($subdomain)
+    {
+        dd($subdomain);
     }
 }

--- a/app/Http/Controllers/Auth/RegisterSubdomainController.php
+++ b/app/Http/Controllers/Auth/RegisterSubdomainController.php
@@ -6,7 +6,6 @@ use App\Actions\Auth\CreateSubdomainAction;
 use App\DataTransferObjects\Auth\SubdomainData;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\SubdomainRequest;
-use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -23,10 +22,10 @@ class RegisterSubdomainController extends Controller
 
         $subdomain = $action->execute($data);
 
-        return Inertia::location(route('subdomain.home', ['subdomain' => $subdomain]));
+        return Inertia::location(route('subdomain.home', ['subdomain' => $subdomain->name]));
     }
 
-    public function example($subdomain)
+    public function example(string $subdomain)
     {
         dd($subdomain);
     }

--- a/app/Http/Controllers/Auth/RegisterSubdomainController.php
+++ b/app/Http/Controllers/Auth/RegisterSubdomainController.php
@@ -6,9 +6,9 @@ use App\Actions\Auth\CreateSubdomainAction;
 use App\DataTransferObjects\Auth\SubdomainData;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\SubdomainRequest;
-use Illuminate\Http\Response as HttpResponse;
 use Inertia\Inertia;
 use Inertia\Response;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
 
 class RegisterSubdomainController extends Controller
 {
@@ -17,7 +17,7 @@ class RegisterSubdomainController extends Controller
         return Inertia::render('Auth/Subdomain');
     }
 
-    public function store(CreateSubdomainAction $action, SubdomainRequest $request): HttpResponse
+    public function store(CreateSubdomainAction $action, SubdomainRequest $request): HttpFoundationResponse
     {
         $data = new SubdomainData(
             ...array_merge($request->validated(), ['user' => $request->user()])

--- a/app/Http/Controllers/Auth/RegisterSubdomainController.php
+++ b/app/Http/Controllers/Auth/RegisterSubdomainController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Actions\Auth\CreateSubdomainAction;
+use App\DataTransferObjects\Auth\SubdomainData;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\SubdomainRequest;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class RegisterSubdomainController extends Controller
+{
+    public function create(): Response
+    {
+        return Inertia::render('Auth/Subdomain');
+    }
+
+    public function store(CreateSubdomainAction $action, SubdomainRequest $request)
+    {
+        $data = new SubdomainData(...$request->validated(), user: $request->user());
+
+        $subdomain = $action->execute($data);
+    }
+}

--- a/app/Http/Controllers/Auth/RegisterSubdomainController.php
+++ b/app/Http/Controllers/Auth/RegisterSubdomainController.php
@@ -6,6 +6,7 @@ use App\Actions\Auth\CreateSubdomainAction;
 use App\DataTransferObjects\Auth\SubdomainData;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\SubdomainRequest;
+use Illuminate\Http\Response as HttpResponse;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -16,7 +17,7 @@ class RegisterSubdomainController extends Controller
         return Inertia::render('Auth/Subdomain');
     }
 
-    public function store(CreateSubdomainAction $action, SubdomainRequest $request)
+    public function store(CreateSubdomainAction $action, SubdomainRequest $request): HttpResponse
     {
         $data = new SubdomainData(
             ...array_merge($request->validated(), ['user' => $request->user()])

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -4,35 +4,23 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
-use App\Providers\RouteServiceProvider;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class RegisteredUserController extends Controller
 {
-    /**
-     * Display the registration view.
-     *
-     * @return \Inertia\Response
-     */
-    public function create()
+    public function create(): Response
     {
         return Inertia::render('Auth/Register');
     }
 
-    /**
-     * Handle an incoming registration request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
-     *
-     * @throws \Illuminate\Validation\ValidationException
-     */
-    public function store(Request $request)
+    public function store(Request $request): RedirectResponse
     {
         $request->validate([
             'first_name' => 'required|string|max:255',
@@ -52,6 +40,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($user);
 
-        return redirect(RouteServiceProvider::HOME);
+        return redirect()->route('register-subdomain');
     }
 }

--- a/app/Http/Requests/Auth/SubdomainRequest.php
+++ b/app/Http/Requests/Auth/SubdomainRequest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SubdomainRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', 'unique:subdomains']
+        ];
+    }
+}

--- a/app/Http/Requests/Auth/SubdomainRequest.php
+++ b/app/Http/Requests/Auth/SubdomainRequest.php
@@ -9,7 +9,7 @@ class SubdomainRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255', 'unique:subdomains']
+            'name' => ['required', 'string', 'max:255', 'unique:subdomains'],
         ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "laravel/framework": "^9.0",
         "laravel/sanctum": "^2.8",
         "laravel/tinker": "^2.7",
-        "spatie/data-transfer-object": "^3.7",
         "spatie/laravel-model-states": "^2.2",
         "spatie/laravel-permission": "^5.5",
         "spatie/laravel-query-builder": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9a07badeeb8452c7f41880c05b4aecc",
+    "content-hash": "dae4ce440094717ff00e1f0ebb99aac1",
     "packages": [
         {
             "name": "brick/math",
@@ -3318,69 +3318,6 @@
                 }
             ],
             "time": "2021-09-25T23:10:38+00:00"
-        },
-        {
-            "name": "spatie/data-transfer-object",
-            "version": "3.7.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/data-transfer-object.git",
-                "reference": "341f72c77e0fce40ea2e0dcb212cb54dc27bbe72"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/data-transfer-object/zipball/341f72c77e0fce40ea2e0dcb212cb54dc27bbe72",
-                "reference": "341f72c77e0fce40ea2e0dcb212cb54dc27bbe72",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.0"
-            },
-            "require-dev": {
-                "illuminate/collections": "^8.36",
-                "jetbrains/phpstorm-attributes": "^1.0",
-                "larapack/dd": "^1.1",
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Spatie\\DataTransferObject\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brent Roose",
-                    "email": "brent@spatie.be",
-                    "homepage": "https://spatie.be",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Data transfer objects with batteries included",
-            "homepage": "https://github.com/spatie/data-transfer-object",
-            "keywords": [
-                "data-transfer-object",
-                "spatie"
-            ],
-            "support": {
-                "issues": "https://github.com/spatie/data-transfer-object/issues",
-                "source": "https://github.com/spatie/data-transfer-object/tree/3.7.3"
-            },
-            "funding": [
-                {
-                    "url": "https://spatie.be/open-source/support-us",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/spatie",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-12-30T20:31:10+00:00"
         },
         {
             "name": "spatie/laravel-model-states",
@@ -9858,5 +9795,5 @@
         "php": "^8.0.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/app.php
+++ b/config/app.php
@@ -56,6 +56,8 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
+    'short_url' => preg_replace('#^https?://#', '', rtrim(env('APP_URL', 'http://localhost'), '/')),
+
     'asset_url' => env('ASSET_URL'),
 
     /*

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\User;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,6 +14,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
+        User::factory()->create([
+            'first_name' => 'Daniel',
+            'last_name' => 'Carney',
+            'email' => 'dancarney@live.co.uk',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+        ]);
     }
 }

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -1,0 +1,13 @@
+# Charts
+
+You may find some documents in this repo with a strange format such as:
+
+````
+```mermaid
+
+Start --> End
+````
+
+This syntax is using [mermaid](https://github.com/mermaid-js/mermaid) to create charts and graphs for markdown files. Since graphs are useful, and we primarily use markdown for documentation, it makes sense to combine the two.
+
+To be able to view these charts/graphs, you should install the following VS Code extension: https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid

--- a/docs/flowcharts/user_registration.md
+++ b/docs/flowcharts/user_registration.md
@@ -1,0 +1,15 @@
+# User registration
+
+User registration can be done either from scratch or after receiving an invite email. The steps taken and information gathered depend on which path is taken. The chart below outlines the different flows.
+
+```mermaid
+flowchart TD
+    Start --> user_invited{Was user invited?}
+    user_invited --> invited_yes[Yes] --> details_invited[Enter details]
+    user_invited --> invited_no[No] --> details_not_invited[Enter details]
+    details_invited --> End
+    details_not_invited --> subdomain[Enter subdomain details]
+    subdomain --> setup_project{Setup project now?}
+    setup_project --> setup_yes[Yes] --> project[Enter project details] --> End
+    setup_project --> setup_no[No] --> End
+```

--- a/resources/js/Pages/Auth/Register.tsx
+++ b/resources/js/Pages/Auth/Register.tsx
@@ -71,7 +71,6 @@ export default function Register() {
             value={data.last_name}
             className="mt-1 block w-full"
             autoComplete="last_name"
-            isFocused
             handleChange={onHandleChange}
             required
           />

--- a/resources/js/Pages/Auth/Subdomain.tsx
+++ b/resources/js/Pages/Auth/Subdomain.tsx
@@ -22,7 +22,7 @@ export const Subdomain: React.FC<ISubdomainProps> = (props) => {
 
   return (
     <>
-      <Head title="Subdomain" />
+      <Head title="Register Subdomain" />
       <ValidationErrors errors={errors} />
 
       <form onSubmit={submit}>

--- a/resources/js/Pages/Auth/Subdomain.tsx
+++ b/resources/js/Pages/Auth/Subdomain.tsx
@@ -11,7 +11,7 @@ export const Subdomain: React.FC<ISubdomainProps> = (props) => {
   })
 
   const onHandleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setData(event.target.name as 'name', event.target.value)
+    setData('name', event.target.value)
   }
 
   const submit = (e: React.SyntheticEvent) => {

--- a/resources/js/Pages/Auth/Subdomain.tsx
+++ b/resources/js/Pages/Auth/Subdomain.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Head, Link, useForm } from '@inertiajs/inertia-react'
+import route from 'ziggy-js'
+import { Button, Input, Label, ValidationErrors } from 'Components'
+
+export interface ISubdomainProps {}
+
+export const Subdomain: React.FC<ISubdomainProps> = (props) => {
+  const { data, setData, post, processing, errors, reset } = useForm({
+    name: '',
+  })
+
+  const onHandleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setData(event.target.name as 'name', event.target.value)
+  }
+
+  const submit = (e: React.SyntheticEvent) => {
+    e.preventDefault()
+
+    post(route('register-subdomain'))
+  }
+
+  return (
+    <>
+      <Head title="Subdomain" />
+      <ValidationErrors errors={errors} />
+
+      <form onSubmit={submit}>
+        <div>
+          <Label forInput="name" value="Name" />
+
+          <Input
+            type="text"
+            name="name"
+            value={data.name}
+            className="mt-1 block w-full"
+            autoComplete="name"
+            isFocused
+            handleChange={onHandleChange}
+            required
+          />
+        </div>
+
+        <Button processing={processing}>Submit</Button>
+      </form>
+    </>
+  )
+}
+
+export default Subdomain

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -7,50 +7,56 @@ use App\Http\Controllers\Auth\EmailVerificationPromptController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
+use App\Http\Controllers\Auth\RegisterSubdomainController;
 use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])
-                ->name('register');
+        ->name('register');
 
     Route::post('register', [RegisteredUserController::class, 'store']);
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
-                ->name('login');
+        ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->name('password.request');
+        ->name('password.request');
 
     Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->name('password.email');
+        ->name('password.email');
 
     Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-                ->name('password.reset');
+        ->name('password.reset');
 
     Route::post('reset-password', [NewPasswordController::class, 'store'])
-                ->name('password.update');
+        ->name('password.update');
 });
 
 Route::middleware('auth')->group(function () {
+    Route::get('register-subdomain', [RegisterSubdomainController::class, 'create'])
+        ->name('register-subdomain');
+
+    Route::post('register-subdomain', [RegisterSubdomainController::class, 'store']);
+
     Route::get('verify-email', [EmailVerificationPromptController::class, '__invoke'])
-                ->name('verification.notice');
+        ->name('verification.notice');
 
     Route::get('verify-email/{id}/{hash}', [VerifyEmailController::class, '__invoke'])
-                ->middleware(['signed', 'throttle:6,1'])
-                ->name('verification.verify');
+        ->middleware(['signed', 'throttle:6,1'])
+        ->name('verification.verify');
 
     Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware('throttle:6,1')
-                ->name('verification.send');
+        ->middleware('throttle:6,1')
+        ->name('verification.send');
 
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
-                ->name('password.confirm');
+        ->name('password.confirm');
 
     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->name('logout');
+        ->name('logout');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,7 @@ use Inertia\Inertia;
 |
 */
 
-Route::domain('{subdomain}.' . config('app.short_url'))->group(function () {
+Route::domain('{subdomain}.'.config('app.short_url'))->group(function () {
     Route::get('/', [RegisterSubdomainController::class, 'example'])->name('subdomain.home');
 });
 
@@ -33,4 +33,4 @@ Route::get('/dashboard', function () {
     return Inertia::render('Dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 
-require __DIR__ . '/auth.php';
+require __DIR__.'/auth.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Auth\RegisterSubdomainController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -15,6 +16,10 @@ use Inertia\Inertia;
 |
 */
 
+Route::domain('{subdomain}.' . config('app.short_url'))->group(function () {
+    Route::get('/', [RegisterSubdomainController::class, 'example'])->name('subdomain.home');
+});
+
 Route::get('/', function () {
     return Inertia::render('Welcome', [
         'canLogin' => Route::has('login'),
@@ -28,4 +33,4 @@ Route::get('/dashboard', function () {
     return Inertia::render('Dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 
-require __DIR__.'/auth.php';
+require __DIR__ . '/auth.php';

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
@@ -16,7 +15,7 @@ it('registers new users', function () {
         'email' => 'test@example.com',
         'password' => 'password',
         'password_confirmation' => 'password',
-    ])->assertRedirect(RouteServiceProvider::HOME);
+    ])->assertRedirect('register-subdomain');
 
     $this->assertAuthenticated();
 });


### PR DESCRIPTION
# Subdomain registration

**Ticket:** N/A

## Description

This PR adds the initial subdomain registration form as part of the registration process.

The user flow for registration can be found in `docs/flowcharts/user_registration.md`, instructions for viewing charts can be found in `docs/charts.md`.

The subdomain registration step is found after registration a fresh account without an invite, doing so will then redirect the user to their new domain. For example, creating a subdomain named 'something' will then direct the user to 'something.localhost'.

The next step will be to define some permissions, probably using guards to separate subdomain and project permissions. Then we can limit access to subdomains as its currently open.

## Checklist

- [x] The `develop` branch has been merged into this branch and conflicts resolved
- [x] All existing tests are passing
- [x] Manual testing has been completed
- [x] Automated tests have been added where necessary
- [x] Documentation has been updated where necessary
